### PR TITLE
Code Manager | Fix phpstan-doctrine config load

### DIFF
--- a/src/CodeAnalyser/phpstan.neon.php
+++ b/src/CodeAnalyser/phpstan.neon.php
@@ -1,19 +1,23 @@
 <?php declare(strict_types=1);
 
 $possiblePaths = [
-    '../../vendor/phpstan/phpstan-doctrine/extension.neon',
-    '../../../../phpstan/phpstan-doctrine/extension.neon',
+    __DIR__ . '/../../vendor/phpstan/phpstan-doctrine/extension.neon',
+    __DIR__ . '/../../../../phpstan/phpstan-doctrine/extension.neon',
 ];
 
-$includes = array_filter($possiblePaths, static fn (string $path) => file_exists($path));
+$includes = array_map(
+    static fn(string $path) => realpath($path),
+    array_values(array_filter(
+        $possiblePaths,
+        static fn(string $path) => file_exists($path)
+    ))
+);
 
 $parameters = [
     'level' => 'max',
 ];
 
-$config = [
+return [
     'includes' => $includes,
     'parameters' => $parameters,
 ];
-
-return $config;


### PR DESCRIPTION
This commit attempts to fix the issue where the phpstan-doctrine configuration was not loading correctly.

This caused certain "errors" to be reported when they shouldn't have. See ![first screenshot](https://github.com/user-attachments/assets/7bc85177-3910-482c-a3c4-db83967dcf42)


After resolving to the actual real paths, the loading proceeds correctly. Attached ![second screenshot](https://github.com/user-attachments/assets/1861bbaf-a943-48b6-8c61-47e5b462f934) to see the absence of errors and the phpstan logs with information about Doctrine.